### PR TITLE
bump facebook-chat-api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/kimberli/hubot-messenger#readme",
   "dependencies": {
-    "facebook-chat-api": "^1.0.2",
+    "facebook-chat-api": "^1.6.1",
     "parent-require": "^1.0.0"
   }
 }


### PR DESCRIPTION
this will enable the adapter to work again and not crash when gifs / emoji / images. 